### PR TITLE
Implemented change so that cab orders are not distributed, but handle…

### DIFF
--- a/Project/distributor/distributor.go
+++ b/Project/distributor/distributor.go
@@ -42,22 +42,24 @@ func Redistribute(elevStateTx chan elevator.Elevator, elevators *[settings.NumEl
 //Receives buttonpress, then calculates optimal elevator wiht cost func,then sends elevOrder which includes order and ID of elev.
 
 
-func DistributeOrder(buttonPress chan elevio.ButtonEvent,  elevOrderTx chan collector.ElevatorOrder,  elevators *[settings.NumElevs]elevator.Elevator){
-	for{
+func DistributeOrder(buttonPress elevio.ButtonEvent,  elevOrderTx chan collector.ElevatorOrder,  elevators *[settings.NumElevs]elevator.Elevator){
+	/*for{
 		select{
 		case buttonPress:=<-buttonPress:
 
-			//Problem her sannsynligvis. Får ikke tak i heis states
-			elevator.Elevator_print(elevators[0])
-		
-			elevOrder := hallAssigner.ChooseOptimalElev(buttonPress, elevators) //choose optimalelev must calculat cost func for all elevs and create order to optimal elevator
+			if buttonPress.Button != elevio.BT_Cab {*/
+				//Problem her sannsynligvis. Får ikke tak i heis states
+				//elevator.Elevator_print(elevators[0])
 			
-			fmt.Printf("\nOptimal elev calculated:\n")
-			fmt.Printf("optimalElevID: " + elevOrder.RecipientID + "\n")
-			fmt.Printf("Floor: %d \n", elevOrder.Order.Floor)
-			fmt.Printf("Button: %d \n", elevOrder.Order.Button)
+				elevOrder := hallAssigner.ChooseOptimalElev(buttonPress, elevators) //choose optimalelev must calculat cost func for all elevs and create order to optimal elevator
 				
-			elevOrderTx<-elevOrder
-		}
-	}
+				fmt.Printf("\nOptimal elev calculated:\n")
+				fmt.Printf("optimalElevID: " + elevOrder.RecipientID + "\n")
+				fmt.Printf("Floor: %d \n", elevOrder.Order.Floor)
+				fmt.Printf("Button: %d \n", elevOrder.Order.Button)
+					
+				elevOrderTx<-elevOrder
+			//}
+		//}
+	//}
 }

--- a/Project/main.go
+++ b/Project/main.go
@@ -81,10 +81,10 @@ func main() {
 	
 	go collector.CollectStates(elevStateRx, &elevators)
 	go distributor.DistributeState(elevStateTx, &elev)
-	go distributor.DistributeOrder(drv_buttons, elevOrderTx, &elevators)
+	//go distributor.DistributeOrder(drv_buttons, elevOrderTx, &elevators)
 
 
-	go fsm.Fsm_server(elevOrderRx, drv_floors, drv_obstr, drv_stop, &elev)
+	go fsm.Fsm_server(elevOrderRx, elevOrderTx, drv_buttons, drv_floors, drv_obstr, drv_stop, &elev, &elevators)
 
 
 


### PR DESCRIPTION
…d locally.

To do this i had to make some changes to how fsm_server and DistributeOrder was organized. This was because the buttonPressed channel was accessed in two places and this made it so you had to press cab buttons twice sometimes (data race?)Now DistributeOrde Now DistributeOrder takes in a regular Buttonevent instead of channel . Now Fsm_server takes in the button presss channel and checks whether it is a cab order or not. If cab order: dont distribute. If not cab order: call on distributeOrder to send to optimal elev.